### PR TITLE
fix(proto-gen): Use the correct path for Coin type

### DIFF
--- a/proto/buf.gen.pulsar.yaml
+++ b/proto/buf.gen.pulsar.yaml
@@ -11,7 +11,7 @@ managed:
 plugins:
   - name: go-pulsar
     out: ..
-    opt: paths=source_relative,Mcosmos/app/v1alpha1/module.proto=cosmossdk.io/api/cosmos/app/v1alpha1
+    opt: paths=source_relative,Mcosmos/app/v1alpha1/module.proto=cosmossdk.io/api/cosmos/app/v1alpha1,Mcosmos/base/v1beta1/coin.proto=cosmossdk.io/api/cosmos/base/v1beta1
   - name: go-grpc
     out: ..
     opt: paths=source_relative,Mcosmos/app/v1alpha1/module.proto=cosmossdk.io/api/cosmos/app/v1alpha1


### PR DESCRIPTION
Without this any `cosmos.base.v1beta1.Coin` will be turnt into a `types.Coin` in generated files